### PR TITLE
Paths to liblcio.so and liblcioDict.so now compatible with x86_64_gcc10_centos7/v02-03/

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ First, write the following lines in your `.rootlogon.C`
 ```
 and add $LCIO/lib and/or $LCIO/lib64 to your LD_LIBRARY_PATH:
 ```
-export LD_LIBRARY_PATH=$LCIO/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LCIO/lib:$LCIO/lib64:$LD_LIBRARY_PATH
 ```
 
 After this, any [LCIO class](https://ilcsoft.desy.de/LCIO/current/doc/doxygen_api/html/classEVENT_1_1LCObject.html) can be used in your ROOT macro.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ First, write the following lines in your `.rootlogon.C`
 ```
 {
  gInterpreter->AddIncludePath("$LCIO");
- gSystem->Load("${LCIO}/lib/liblcio.so");
- gSystem->Load("${LCIO}/lib/liblcioDict.so");
+ gSystem->Load("liblcio.so");
+ gSystem->Load("liblcioDict.so");
 }
 ```
 and add $LCIO/lib to your LD_LIBRARY_PATH:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ First, write the following lines in your `.rootlogon.C`
  gSystem->Load("liblcioDict.so");
 }
 ```
-and add $LCIO/lib to your LD_LIBRARY_PATH:
+and add $LCIO/lib and/or $LCIO/lib64 to your LD_LIBRARY_PATH:
 ```
 export LD_LIBRARY_PATH=$LCIO/lib:$LD_LIBRARY_PATH
 ```

--- a/examples/.rootlogon.C
+++ b/examples/.rootlogon.C
@@ -3,8 +3,8 @@
 // these three lines are essential, don't touch
  
 gInterpreter->AddIncludePath("$LCIO");
-gSystem->Load("${LCIO}/lib/liblcio.so");
-gSystem->Load("${LCIO}/lib/liblcioDict.so");
+gSystem->Load("liblcio.so");
+gSystem->Load("liblcioDict.so");
 
 // the stuff below you can adjust to your needs
 

--- a/examples/higgs_recoil.C
+++ b/examples/higgs_recoil.C
@@ -17,8 +17,8 @@ put this into your .rootlogon.C file
 
 {
  gInterpreter->AddIncludePath("$LCIO");
- gSystem->Load("${LCIO}/lib/liblcio.so");
- gSystem->Load("${LCIO}/lib/liblcioDict.so");
+ gSystem->Load("liblcio.so");
+ gSystem->Load("liblcioDict.so");
 }
 
 for the LCIO API documentation see:

--- a/examples/higgs_recoil_with_bkg.C
+++ b/examples/higgs_recoil_with_bkg.C
@@ -17,8 +17,8 @@ put this into your .rootlogon.C file
 
 {
  gInterpreter->AddIncludePath("$LCIO");
- gSystem->Load("${LCIO}/lib/liblcio.so");
- gSystem->Load("${LCIO}/lib/liblcioDict.so");
+ gSystem->Load("liblcio.so");
+ gSystem->Load("liblcioDict.so");
 }
 
 for the LCIO API documentation see:

--- a/examples/jet_btag.C
+++ b/examples/jet_btag.C
@@ -17,8 +17,8 @@ put this into your .rootlogon.C file
 
 {
  gInterpreter->AddIncludePath("$LCIO");
- gSystem->Load("${LCIO}/lib/liblcio.so");
- gSystem->Load("${LCIO}/lib/liblcioDict.so");
+ gSystem->Load("liblcio.so");
+ gSystem->Load("liblcioDict.so");
 }
 
 for the LCIO API documentation see:

--- a/examples/walkthrough_ana.C
+++ b/examples/walkthrough_ana.C
@@ -37,8 +37,8 @@
 
   {
   gInterpreter->AddIncludePath("$LCIO");
-  gSystem->Load("${LCIO}/lib/liblcio.so");
-  gSystem->Load("${LCIO}/lib/liblcioDict.so");
+  gSystem->Load("liblcio.so");
+  gSystem->Load("liblcioDict.so");
   }
 
   for the LCIO API documentation see:


### PR DESCRIPTION
Make sure that examples work with newer versions of iLCSoft, where the LCIO installation layout has changed.

@tmadlener